### PR TITLE
Enable filtering by field data based on application properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ bin/main/application.yaml
 *.csv
 *.jsonl
 *.zip
+*.gz
 unit-test-*

--- a/src/functionalTest/java/uk/gov/hmcts/reform/mi/miextractionservice/data/TestConstants.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/mi/miextractionservice/data/TestConstants.java
@@ -2,18 +2,27 @@ package uk.gov.hmcts.reform.mi.miextractionservice.data;
 
 @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
 public final class TestConstants {
-    
+
     public static final String TEST_CONTAINER_NAME = "test-testcontainer";
     public static final String TEST_EXTRACTION_CONTAINER_NAME = "extraction-test";
+    public static final String TEST_FILTER_CONTAINER_NAME = "filter-test";
     public static final String TEST_BLOB_NAME = "testblob-1970-01";
 
     public static final String EXPORT_CONTAINER_NAME = "test";
     public static final String EXPORT_EXTRACTION_CONTAINER_NAME = "extraction-test";
+    public static final String EXPORT_FILTER_CONTAINER_NAME = "filter-test";
     public static final String TEST_EXPORT_BLOB = "test-1970-01-01-1970-01-02.zip";
     public static final String TEST_EXTRACTION_EXPORT_BLOB = "extraction-test-1970-01-01-1970-01-02.zip";
+    public static final String TEST_FILTER_EXPORT_BLOB = "filter-test-1970-01-01-1970-01-02.zip";
+
+    public static final String EXTRACT_FILE_NAME = "test-1970-01-01-1970-01-02.jsonl.gz";
+    public static final String EXTRACT_FILTER_FILE_NAME = "filter-test-1970-01-01-1970-01-02.jsonl.gz";
 
     public static final String TEST_JSONL = "{\"extraction_date\":\"19700101-1010\",\"date_updated\":\"1970-01-01T10:00:00.000Z\","
                                             + "\"hello\":\"world's\"}";
+
+    public static final String TEST_FILTER_PASS_JSONL = "{\"extraction_date\":\"19700101-1010\",\"test\":\"pass\"}";
+    public static final String TEST_FILTER_FAIL_JSONL = "{\"extraction_date\":\"19700101-1010\",\"test\":\"fail\"}";
 
     private TestConstants() {
         // Private constructor

--- a/src/functionalTest/resources/application.yaml
+++ b/src/functionalTest/resources/application.yaml
@@ -38,6 +38,11 @@ export:
     extraction-test:
       enabled: true
       date-field: extraction_date
+    filter-test:
+      enabled: true
+      date-field: extraction_date
+      filters:
+        - test=pass
 
 # Whitelist
 container-whitelist: ^.*test.*

--- a/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponent.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.mi.miextractionservice.component.filter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import uk.gov.hmcts.reform.mi.miextractionservice.domain.SourceProperties;
+
+public interface FilterComponent {
+
+    boolean filter(JsonNode data, SourceProperties sourceProperties);
+}

--- a/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponentImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponentImpl.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.mi.miextractionservice.component.filter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import uk.gov.hmcts.reform.mi.miextractionservice.domain.SourceProperties;
+import uk.gov.hmcts.reform.mi.miextractionservice.exception.ParserException;
+
+import java.util.regex.Pattern;
+
+@Slf4j
+@Component
+public class FilterComponentImpl implements FilterComponent {
+
+    private static final int MAX_FILTER_PARTS = 2;
+
+    @Override
+    public boolean filter(JsonNode data, SourceProperties sourceProperties) {
+        boolean passFilters = true;
+
+        if (sourceProperties.getFilters() != null) {
+            for (String filter : sourceProperties.getFilters()) {
+                String[] parsedFilter = buildFilter(filter);
+                passFilters = Boolean
+                    .logicalAnd(
+                        passFilters,
+                        Pattern.compile(parsedFilter[1]).matcher(data.get(parsedFilter[0]).asText()).matches()
+                    );
+            }
+        }
+
+        return passFilters;
+    }
+
+    private String[] buildFilter(String filterString) {
+        String[] parsedFilter = filterString.split("=");
+        if (parsedFilter.length != MAX_FILTER_PARTS) {
+            throw new ParserException("Filter string is not in the correct format: " + filterString);
+        }
+
+        return parsedFilter;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/component/writer/DataWriterComponentImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/component/writer/DataWriterComponentImpl.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import uk.gov.hmcts.reform.mi.miextractionservice.component.filter.DateFilterComponent;
+import uk.gov.hmcts.reform.mi.miextractionservice.component.filter.FilterComponent;
 import uk.gov.hmcts.reform.mi.miextractionservice.component.parser.DataParserComponent;
 import uk.gov.hmcts.reform.mi.miextractionservice.domain.SourceProperties;
 import uk.gov.hmcts.reform.mi.miextractionservice.exception.ExportException;
@@ -25,6 +26,7 @@ public class DataWriterComponentImpl implements DataWriterComponent {
 
     private final DataParserComponent dataParserComponent;
     private final DateFilterComponent dateFilterComponent;
+    private final FilterComponent filterComponent;
 
     @Override
     public int writeRecordsForDateRange(BufferedWriter bufferedWriter,
@@ -43,7 +45,9 @@ public class DataWriterComponentImpl implements DataWriterComponent {
             while (line != null) {
                 if (StringUtils.isNotEmpty(line)) {
                     JsonNode jsonNode = dataParserComponent.parseJsonString(line);
-                    if (dateFilterComponent.filterByDate(jsonNode, sourceProperties, fromDate, toDate)) {
+                    if (dateFilterComponent.filterByDate(jsonNode, sourceProperties, fromDate, toDate)
+                        && filterComponent.filter(jsonNode, sourceProperties)) {
+
                         bufferedWriter.write(line);
                         bufferedWriter.newLine();
                         recordsCount++;

--- a/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/domain/SourceProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/domain/SourceProperties.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Value;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
+import java.util.List;
+
 @Builder
 @Value
 @ConstructorBinding
@@ -14,4 +16,5 @@ public class SourceProperties {
     String dateField;
     String timezone;
     SourceTypeEnum type;
+    List<String> filters;
 }

--- a/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/exception/ExportException.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/exception/ExportException.java
@@ -4,10 +4,6 @@ public class ExportException extends RuntimeException {
 
     public static final long serialVersionUID = 8999L;
 
-    public ExportException(String message) {
-        super(message);
-    }
-
     public ExportException(String message, Throwable exception) {
         super(message, exception);
     }

--- a/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/exception/ParserException.java
+++ b/src/main/java/uk/gov/hmcts/reform/mi/miextractionservice/exception/ParserException.java
@@ -4,6 +4,10 @@ public class ParserException extends RuntimeException {
 
     public static final long serialVersionUID = 159280L;
 
+    public ParserException(String message) {
+        super(message);
+    }
+
     public ParserException(String message, Throwable exception) {
         super(message, exception);
     }

--- a/src/test/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponentImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponentImplTest.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.mi.miextractionservice.component.filter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import uk.gov.hmcts.reform.mi.miextractionservice.domain.SourceProperties;
+import uk.gov.hmcts.reform.mi.miextractionservice.exception.ParserException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+class FilterComponentImplTest {
+
+    private FilterComponent classToTest;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        classToTest = new FilterComponentImpl();
+
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void givenNoFiltersOnSourceProperty_whenFilter_thenReturnTrue() {
+        assertTrue(classToTest.filter(null, SourceProperties.builder().build()),
+                   "Filter should return true when nothing to filter.");
+    }
+
+    @Test
+    void givenMultipleFiltersThatPass_whenFilter_thenReturnTrue() throws Exception {
+        final JsonNode jsonNode = objectMapper.readTree("{\"test\":\"data\",\"hello\":\"world\"}");
+        final List<String> filters = ImmutableList.of("test=data","hello=world");
+        assertTrue(classToTest.filter(jsonNode, SourceProperties.builder().filters(filters).build()),
+                   "Filter should return true when all filters pass.");
+    }
+
+    @Test
+    void givenMultipleFiltersWithOneThatFails_whenFilter_thenReturnFalse() throws Exception {
+        final JsonNode jsonNode = objectMapper.readTree("{\"test\":\"fails\",\"hello\":\"world\"}");
+        final List<String> filters = ImmutableList.of("test=data","hello=world");
+        assertFalse(classToTest.filter(jsonNode, SourceProperties.builder().filters(filters).build()),
+                    "Filter should return false when one filter fails to pass.");
+    }
+
+    @Test
+    void givenInvalidFilter_whenFilter_thenThrowParserException() {
+        final List<String> filters = ImmutableList.of("broken=filter=is");
+        assertThrows(ParserException.class, () -> classToTest.filter(null, SourceProperties.builder().filters(filters).build()));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponentImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/mi/miextractionservice/component/filter/FilterComponentImplTest.java
@@ -56,6 +56,7 @@ class FilterComponentImplTest {
     @Test
     void givenInvalidFilter_whenFilter_thenThrowParserException() {
         final List<String> filters = ImmutableList.of("broken=filter=is");
-        assertThrows(ParserException.class, () -> classToTest.filter(null, SourceProperties.builder().filters(filters).build()));
+        SourceProperties sourceProperties = SourceProperties.builder().filters(filters).build();
+        assertThrows(ParserException.class, () -> classToTest.filter(null, sourceProperties));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Allows filtering of data based on field name to regex value checks.
Prompted by end user asking for specific CCD case type data when by default all CCD data is concatenated into a single file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
